### PR TITLE
Add Code of Conduct

### DIFF
--- a/policies/CODE_OF_CONDUCT.md
+++ b/policies/CODE_OF_CONDUCT.md
@@ -1,0 +1,19 @@
+# Code of Conduct
+
+Our meetup is dedicated to providing a harassment-free meetup experience for everyone, regardless of gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, or religion (or lack thereof).
+
+We do not tolerate harassment of meetup participants in any form. Sexual language and imagery is not appropriate for any meetup venue, including talks, workshops, parties, Twitter and other online media. Meetup participants violating these rules may be sanctioned or expelled from the meetup at the discretion of the meetup organizers without a refund.
+
+Harassment includes offensive verbal comments related to gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention.
+
+Participants asked to stop any harassing behavior are expected to comply immediately.
+
+Sponsors are also subject to the anti-harassment policy. In particular, sponsors should not use sexualised images, activities, or other material. Booth staff (including volunteers) should not use sexualised clothing/uniforms/costumes, or otherwise create a sexualised environment.
+
+If a participant engages in harassing behavior, the meetup organisers may take any action they deem appropriate, including warning the offender or expulsion from the meetup with no refund.
+
+If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of meetup staff immediately.
+
+Meetup staff - identified by staff badges - will be happy to help participants contact venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the meetup. We value your attendance.
+
+_Original Code of Conduct source and credit: PHP × NYC, Laracon AU, JSConf.us, and The Ada Initiative. This work is licensed under a Creative Commons Attribution 3.0 Unported License._


### PR DESCRIPTION
Add Code of Conduct. Inspired by the code of conduct of the [PHP × NYC meetup](https://phpxnyc.com/code-of-conduct).
